### PR TITLE
fix(api/boards): prevent non-cascade delete and make new board defaul…

### DIFF
--- a/apps/api/src/boards/boards.service.ts
+++ b/apps/api/src/boards/boards.service.ts
@@ -1,4 +1,4 @@
-import {BadRequestException, Injectable, NotFoundException} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
@@ -6,43 +6,41 @@ import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class BoardsService {
-    constructor(private prisma: PrismaService) {
-    }
+    constructor(private prisma: PrismaService) {}
 
     async findMany(workspaceId: string) {
         return this.prisma.board.findMany({
-            where: {workspaceId},
-            orderBy: {order: 'asc'},
-            include: {columns: {orderBy: {order: 'asc'}}},
+            where: { workspaceId },
+            orderBy: { order: 'asc' },
+            include: { columns: { orderBy: { order: 'asc' } } },
         });
     }
 
     async findOne(id: string) {
         const board = await this.prisma.board.findUnique({
-            where: {id},
-            include: {columns: {orderBy: {order: 'asc'}}},
+            where: { id },
+            include: { columns: { orderBy: { order: 'asc' } } },
         });
-        if (!board) throw new NotFoundException('Board not found');
+        if (!board) throw new NotFoundException('BOARD_NOT_FOUND');
         return board;
     }
 
     async create(dto: CreateBoardDto) {
+        const agg = await this.prisma.board.aggregate({
+            where: { workspaceId: dto.workspaceId },
+            _min: { order: true },
+        });
+        const nextOrder = (agg._min.order ?? 0) - 1;
+
         return this.prisma.board.create({
-            data: {
-                name: dto.name,
-                workspaceId: dto.workspaceId,
-            },
+            data: { name: dto.name, workspaceId: dto.workspaceId, order: nextOrder },
         });
     }
 
     async update(id: string, dto: UpdateBoardDto) {
         return this.prisma.board.update({
-            where: {id},
-            data: {
-                name: dto.name,
-                workspaceId: dto.workspaceId,
-                order: dto.order,
-            },
+            where: { id },
+            data: { name: dto.name, workspaceId: dto.workspaceId, order: dto.order },
         });
     }
 
@@ -58,16 +56,17 @@ export class BoardsService {
     }
 
     async deleteBoard(id: string, cascade = false): Promise<void> {
-        const board = await this.prisma.board.findUnique({
-            where: { id },
-            include: { columns: { select: { id: true } } },
-        });
-        if (!board) throw new NotFoundException('BOARD_NOT_FOUND');
+        const exists = await this.prisma.board.findUnique({ where: { id }, select: { id: true } });
+        if (!exists) throw new NotFoundException('BOARD_NOT_FOUND');
 
-        const columnIds = board.columns.map((c: { id: string }) => c.id);
-        if (!cascade && columnIds.length > 0) {
-            throw new BadRequestException('BOARD_DELETE_RESTRICT');
+        if (!cascade) {
+            throw new ConflictException('BOARD_DELETE_RESTRICT');
         }
+
+        const columnIds = (await this.prisma.boardColumn.findMany({
+            where: { boardId: id },
+            select: { id: true },
+        })).map((c) => c.id);
 
         await this.prisma.$transaction(async (tx) => {
             if (columnIds.length) {
@@ -87,10 +86,7 @@ export class BoardsService {
                     include: {
                         issues: {
                             orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
-                            include: {
-                                assignee: true,
-                                comments: true,
-                            },
+                            include: { assignee: true, comments: true },
                         },
                     },
                 },


### PR DESCRIPTION
…t by order

- DELETE /boards/:id: only treat cascade when query === true|1|yes|on; otherwise 409
- BoardsService.deleteBoard: if cascade=false → always 409 (BOARD_DELETE_RESTRICT)
- BoardsService.create: insert with (min(order) - 1) so the new board becomes default on refresh
- GET /boards/:id/full: return 200 JSON (e.g., { deleted: true }) to avoid frontend JSON parse errors
- POST /boards: accept workspaceId from body/query/header or DEFAULT_WORKSPACE_ID; accept name/title

Files:
- apps/api/src/boards/boards.controller.ts
- apps/api/src/boards/boards.service.ts